### PR TITLE
add support for Hexo v6

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   },
   "homepage": "https://github.com/liolok/hexo-asset-link#readme",
   "peerDependencies": {
-    "hexo": "^4.0.0 || ^5.0.0"
+    "hexo": "^4.0.0 || ^5.0.0 || ^6.0.0"
   }
 }


### PR DESCRIPTION
Hexo 6.0.0 Released in a mouth ago, there is no breaking changes that conflicts with this plugin.

 I think it's suitable to add hexo v6 in peerDepenencies and publish a new release v2.1.1